### PR TITLE
扱うデータをdictionary化する

### DIFF
--- a/tododb.py
+++ b/tododb.py
@@ -1,5 +1,12 @@
 import sqlite3
 import datetime
+import re
+
+DEFAULT = {"title": "Noname", "limit_at": "2999/12/31 23:59",
+           "update_at": "2000/01/01 0:00", "status": "未"}
+DEFAULT_TYPE = {"title": "text NOT NULL", "limit_at": "text",
+                "update_at": "text NOT NULL", "status": "text"}
+
 
 class DB(object):
     def __init__(self, name):
@@ -7,9 +14,14 @@ class DB(object):
         self.__c = self.__conn.cursor()
 
     def __create_table(self):
-        self.__c.execute("create table todo" \
-                         "(id integer NOT NULL PRIMARY KEY AUTOINCREMENT, " \
-                          "title text NOT NULL, limit_at text, update_at text NOT NULL)")
+        keys = DEFAULT.keys()
+        msg = "(id integer NOT NULL PRIMARY KEY AUTOINCREMENT"
+        for key in keys:
+            if key == "id":
+                continue
+            msg += f",{key} {DEFAULT_TYPE[key]}"
+        msg += ")"
+        self.__c.execute(f"create table todo {msg}")
 
     def __drop_table(self):
         self.__c.execute("drop table todo")
@@ -21,11 +33,46 @@ class DB(object):
         self.__drop_table()
         self.__create_table()
 
+
+    # 追加するデータをdictionaryで受け取る
+    # 引数 (self,追加したいデータ)
+    def add_dict(self, dict):
+        # 基本としてデフォルトを読み込む
+        newdata = {}
+        for key in DEFAULT.keys():
+            newdata[key] = DEFAULT[key]
+        dict_items = dict.items()
+        # dictの中身をnewdataに上書き
+        for item in dict_items:
+            if item[0] in newdata.keys():
+                newdata[item[0]] = item[1]
+        # ここで、limit_atがちゃんとフォーマットにあっているか見る
+        if not re.match(r'^\d{4}/\d{2}/\d{2} \d{1,2}:\d{2}$', newdata["limit_at"]):
+            newdata["limit_at"] = DEFAULT["limit_at"]
+        # 現在時刻取得
+        update_at = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        # sql文を作文
+        msg1 = "insert into todo ("
+        msg2 = "values("
+        datalist = []
+        for tag in newdata.keys():
+            if tag == "update_at":
+                continue
+            msg1 += f"{tag},"
+            msg2 += "?,"
+            datalist.append(newdata[tag])
+        msg1 += "update_at)"
+        msg2 += "?)"
+        datalist.append(update_at)
+        sql = msg1+msg2
+        self.__c.execute(sql, datalist)
+        self.__conn.commit()
+
+
     def add(self, title, limit_at):
         update_at = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        sql = "insert into todo (title, limit_at, update_at) values (?, ?, ?)"
-        self.__c.execute(sql, [title, limit_at, update_at])
-        self.__conn.commit()
+        self.add_dict({"title":title,"limit_at":limit_at,"update_at":update_at})
+
 
     def list(self):
         str_list = "TODO list:\n"

--- a/tododb.py
+++ b/tododb.py
@@ -1,6 +1,7 @@
 import sqlite3
 import datetime
 import re
+import time
 
 DEFAULT = {"title": "Noname", "limit_at": "2999/12/31 23:59",
            "update_at": "2000/01/01 0:00", "status": "未"}
@@ -80,5 +81,20 @@ class DB(object):
             str_list += ', '.join(map(str, r))
             str_list += '\n'
         return str_list
+
+    def dict_list(self):
+        dict_list = []
+        columns = self.__conn.execute("select * from todo").description
+        for i in range(20):
+            fromnum = i*50+1
+            tonum = (i+1)*50
+            for r in self.__c.execute(f"select * from todo WHERE id BETWEEN {fromnum} and {tonum}"):
+                item = list(map(str, r))
+                dict = {}
+                for i in range(len(columns)):
+                    dict[columns[i][0]] = item[i]
+                    i += 1
+                dict_list.append(dict)
+        return dict_list
 
 

--- a/tododb.py
+++ b/tododb.py
@@ -34,6 +34,27 @@ class DB(object):
         self.__drop_table()
         self.__create_table()
 
+    
+    # idでデータを取得してdict形式で返す
+    # idが存在しない値であるときは全要素Noneで返すので注意
+    def select_id(self, id):
+        dict_list = []
+        columns = self.__conn.execute("select * from todo").description
+        for r in self.__c.execute(f"select * from todo where id=={id}"):
+            item = list(map(str, r))
+            dict = {}
+            for i in range(len(columns)):
+                dict[columns[i][0]] = item[i]
+                i += 1
+            dict_list.append(dict)
+        if len(dict_list) == 0:
+            dict = {}
+            for i in range(len(columns)):
+                dict[columns[i][0]] = None
+                i += 1
+            dict_list.append(dict)
+        return dict_list[0]
+
 
     # 追加するデータをdictionaryで受け取る
     # 引数 (self,追加したいデータ)


### PR DESCRIPTION
以下tododb.pyの更新内容です。
- `add_dict`にテーブルの列名をキー、データの値を値とするdictを与えることで不足データをデフォルトの値で補いつつDBに追加します。
例:課題名が課題1、2999/12/31 までの課題の場合
```python
database = DB(os.environ['TODO_DB'])
database.add_dict({"title":"課題1","limit_at":"2999/12/31 23:59"})

# 今回の例では、仮にDBのテーブルの列にstatus,subjectなどもあったとして、以下のように追加されます。
#title = 課題1    dictのデータが反映されます。デフォルトでは"noname"という名前になります。
#limit_at = 2999/12/31 23:59    4桁/2桁/2桁 1~2桁:2桁の形である限りdictのデータが反映されます。デフォルトでは"2999/12/31 23:59"になります。
#update_at =(この作業を行った時刻)    必ずこの作業を行った時刻になります。
#subject =(デフォルト)    今回は何の値も与えていないのでデフォルトの何かになります
#status=(デフォルト)    今回は何の値も与えていないのでデフォルトの何かになります
```
- `dict_list`を呼び出すことでDB内の各データをそれぞれdictにして、そのリストを返します。
例:課題名が課題1、2999/12/31 までの課題と課題名が課題2、2020/7/13  22:00までの課題の場合
```python
database = DB(os.environ['TODO_DB'])
datalist=database.dict_list() # データを取得

print(datalist[0]) # 下のように表示されます
# {"title":"課題1","limit_at":"2999/12/31 23:59"}

print(datalist[1]) # 下のように表示されます
# {"title":"課題2","limit_at":"2020/07/13 22:00"}

print(datalist[0]["title"]) # 下のように表示されます
# 課題1
```
- `select_id`を呼び出すことでDB内でidに一致するデータをそれぞれdictにして返します。
例 id1番が　タイトル課題1、期限が2999/12/31 の場合
```python
database = DB(os.environ['TODO_DB'])
data=database.select_id(1) #　id1のデータを取得

print(data) # 下のように表示されます
# {"title":"課題1","limit_at":"2999/12/31 23:59"}

data=database.select_id(2) #　id2のデータを取得(DBに入っていない)

print(data) # 下のように表示されます
# {"title":None,"limit_at":None}

```