### PR TITLE
slack上のユーザーidを取り入れる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.db
 .DS_Store
 __pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -19,21 +19,32 @@ ToDo 管理とその他さまざまな反応をする slackbot
   - `@bot todo search '検索文字列'`: 検索文字列がtitleに含まれている場合、その内容を表示する
 
 ## ToDo DBのスキーマ
-| id | title |     limit_at     |    update_at     | status |  noticetime  |
-|----|-------|------------------|------------------|--------|--------------|
-|  1 | test1 | 2020/04/30 23:59 | 2020/04/01 13:10 |   済   |       0      |
-|  2 | test2 | 2020/07/30 7:05  | 2020/06/01 17:00 |   未   |       3      |
+| id | title |     limit_at     |    update_at     | status |  noticetime  |    user     |
+|----|-------|------------------|------------------|--------|--------------|-------------|
+|  1 | test1 | 2020/04/30 23:59 | 2020/04/01 13:10 |   済   |       0      | S2340A7K6Q4 |
+|  2 | test2 | 2020/07/30 7:05  | 2020/06/01 17:00 |   未   |       3      | S2340A7K6Q4 |
+* 上のuseridは存在しないものである
 
 ## ToDo DBの操作関数
 * `add(title, limit_at)`: title と limit_at (有効期限) を登録
 * `add(title)`: title を無期限の有効期限として登録
 * `list()`: ToDo DB のデータを一覧した文字列を返す
 * `reset()`: ToDo DB の内容を削除し，空のデータベースを作成
-* `add_dict()`:列名をkey、データの値をvalueとするdictのデータをToDo DBに登録　#6　に詳細あり
+* `add_dict(data)`:列名をkey、データの値をvalueとするdictのデータをToDo DBに登録　#6　に詳細あり
 * `dict_list()`ToDo DB の各データをそれぞれdictにして、dictのリストを返す #6　に詳細あり
-* `select_id()`指定したidのデータをdictにして返す #6　に詳細あり
+* `select_id(id)`指定したidのデータをdictにして返す #6　に詳細あり
+* `clean()`主に開発時、テーブルの列の更新、不正なデータの削除を行う
 * `change_id(id, column, value)`指定したidのデータの値を変更する
 * `search(column, text)`columnの値にtextが含まれる場合そのデータをlist形式(要素はdict形式)で返す
+
+## 諸機能の補助関数(tools.py)
+* `getmsginfo(message)`:messageからユーザー情報を取得
+* `datetrans(limit_at, now, mode=0)`:userが入力した文字列(limit_at)を既定の形式に変換する
+* `limit_datetime(assignment, mode=0)`:datetime型でlimit_atを返す
+* `autostatus(assignment, now, mode=0)`:assignmentの期限と現在時刻からstatusを判定
+* `postMessage(text, attachments, channel, username="お知らせ", icon_emoji)`:messageをpost
+* `updateMessage(text, attachments, ts, channel, username="お知らせ", icon_emoji)`:messageを編集
+* `noticetimeSet(limit_at:datetime, now)`:期限から残り通知回数を定める
 
 ## テスト用プログラム
 * test_regex.py

--- a/plugins/notice.py
+++ b/plugins/notice.py
@@ -20,6 +20,9 @@ class Notice():
         self.dict_list = db.dict_list()
         self.channel = os.environ['SLACK_CHANNEL']
         for dict in self.dict_list:
+            # 前バージョンとの互換性を保つ
+            if not "noticetime" in dict.keys():
+                continue
             noticetime = int(dict['noticetime'])
             try:
                 self.__limit_at = dt.datetime.strptime(dict["limit_at"], '%Y/%m/%d %H:%M')

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -24,6 +24,8 @@ def todo_add(message, title, limit_at):
     data = database.add_dict(data)
     msg += "追加しました。"
     for item in data.items():
+        if item[0]=="user":
+            continue
         msg+=f"\n{item[0]}: {item[1]}"
     message.reply(msg)
 

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -6,24 +6,25 @@ import datetime
 
 @respond_to(r'\s+todo\s+add\s+(\S+)\s+(\S+)$')
 def todo_add(message, title, limit_at):
+    # ユーザー情報取得
+    info=tools.getmsginfo(message)
+    data= {"title": title, "limit_at": limit_at,"user": info["user_id"]}
     database = DB(os.environ['TODO_DB'])
     now = datetime.datetime.now()
     limit_at_fin = tools.datetrans(limit_at, now)
-    status = '未'
-    if limit_at_fin == None:
-        database.add_dict(
-            {"title": title, "limit_at": limit_at, "status": status, "noticetime":3})
-        msg = "以下の内容で追加しました。\ntitle:" + title + \
-            "\nlimit:" + limit_at + "\nstatus:" + status
-    else:
+    msg="以下の内容で"
+    if limit_at_fin != None:
         limit_at_format = datetime.datetime.strptime(limit_at_fin, '%Y/%m/%d %H:%M')
         if now > limit_at_format:
-            status = '期限切れ'
+            data["status"] = '期限切れ'
         noticetime = tools.noticetimeSet(limit_at_format, now)
-        database.add_dict(
-            {"title": title, "limit_at": limit_at_fin, "status": status, "noticetime":noticetime})
-        msg = "以下の内容で、期限を正しく設定して追加しました。\ntitle:" + title + \
-            "\nlimit:" + limit_at_fin + "\nstatus:" + status
+        data["noticetime"]=noticetime
+        data["limit_at"]=limit_at_fin
+        msg += "、期限を正しく設定して"
+    data = database.add_dict(data)
+    msg += "追加しました。"
+    for item in data.items():
+        msg+=f"\n{item[0]}: {item[1]}"
     message.reply(msg)
 
 @respond_to(r'\s+todo\s+add\s+(\S+)$')

--- a/plugins/tools.py
+++ b/plugins/tools.py
@@ -5,6 +5,25 @@ import json
 import re
 from dateutil.relativedelta import relativedelta
 
+
+# 今後誰かが取得したくなった時の参考にchannel名、相手の名前等を取得する方法を載せておく
+def getmsginfo(message)-> dict:
+    """ユーザー情報をdict形式で返す
+    現在得られるのは
+    
+    channel:チャンネル名
+
+    user_id:ユーザー固有のid
+
+    user_name:ユーザー名
+    """
+    info_dict={}
+    info_dict["channel"] = message.channel._body["name"]
+    info_dict["user_id"] = message.user["id"]
+    info_dict["user_name"] = message.user["real_name"]
+    return info_dict
+
+
 #userが入力した文字列(limit_at)を既定の形式に変換する
 def datetrans(limit_at, now, mode=0):
     #　例で2020年8月16日19時18分のコマンドを記述しておく

--- a/tododb.py
+++ b/tododb.py
@@ -5,9 +5,9 @@ import time
 from plugins import tools
 
 DEFAULT = {"title": "Noname", "limit_at": "2999/12/31 23:59",
-           "update_at": "2000/01/01 0:00", "status": "未", "noticetime":3}
+           "update_at": "2000/01/01 0:00", "status": "未", "noticetime": 3, "user": None}
 DEFAULT_TYPE = {"title": "text NOT NULL", "limit_at": "text",
-                "update_at": "text NOT NULL", "status": "text", "noticetime":"integer NOT NULL"}
+                "update_at": "text NOT NULL", "status": "text", "noticetime": "integer NOT NULL", "user": "text"}
 
 
 class DB(object):

--- a/tododb.py
+++ b/tododb.py
@@ -88,10 +88,12 @@ class DB(object):
         return dict_list[0]
 
 
-    def add_dict(self, data:dict):
+    def add_dict(self, data:dict)-> dict:
         """追加するデータをdictionaryで受け取る
         
         引数 (self,追加したいデータ:dict)
+
+        return 追加したデータ
 
         dictの要素の過不足はDEFAULTが補正してくれる
         """
@@ -108,7 +110,8 @@ class DB(object):
         if not re.match(r'^\d{4}/\d{2}/\d{2} \d{1,2}:\d{2}$', newdata["limit_at"]):
             newdata["limit_at"] = DEFAULT["limit_at"]
         # 現在時刻取得
-        update_at = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        update_at = datetime.datetime.now().strftime('%Y/%m/%d %H:%M')
+        newdata["update_at"] = update_at
         # sql文を作文
         msg1 = "insert into todo ("
         msg2 = "values("
@@ -125,6 +128,7 @@ class DB(object):
         sql = msg1+msg2
         self.__c.execute(sql, datalist)
         self.__conn.commit()
+        return newdata
 
 
     def change_id(self, id, column, value):


### PR DESCRIPTION
主な変更点は以下の通りです。
- tools.pyの`getmsginfo()`を用いてメンション相手の情報(user_id,user_name,channel)を取得できるようにする。
この関数の戻り値を用いることで例えば返答時にメンション相手の名前で「○○さん」と呼びかけることができます。
- テーブルにuser列を追加。userにはslack上でのユーザーの固有IDが格納される。DEFAULTではNoneになってしまうので注意。
- `add_dict()`が追加したデータをdictで返すようになる。この戻り値をslackでの返答に用いればどのようなデータとして追加されたか確認が可能。