### PR TITLE
delete列の追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -17,6 +17,8 @@ need_init = not os.path.exists(dbname)
 database = DB(dbname)
 if need_init:
     database.init()
+#列追加、減少を自動反映
+database.clean()
 
 
 def noticeThread():

--- a/test_tododb.py
+++ b/test_tododb.py
@@ -6,6 +6,8 @@ need_init = not os.path.exists(dbname)
 database = DB(dbname)
 if need_init:
     database.init()
+#列追加、減少を自動反映
+database.clean()
 
 database.add('test-title1', '2020-06-01')
 print(database.list())

--- a/tododb.py
+++ b/tododb.py
@@ -215,16 +215,13 @@ class DB(object):
         """
         dict_list = []
         columns = self.__conn.execute("select * from todo").description
-        for i in range(20):
-            fromnum = i*50+1
-            tonum = (i+1)*50
-            for r in self.__c.execute(f"select * from todo WHERE id BETWEEN {fromnum} and {tonum}"):
-                item = list(map(str, r))
-                data = {}
-                for i in range(len(columns)):
-                    data[columns[i][0]] = item[i]
-                    i += 1
-                dict_list.append(data)
+        for r in self.__c.execute(f"select * from todo"):
+            item = list(map(str, r))
+            data = {}
+            for i in range(len(columns)):
+                data[columns[i][0]] = item[i]
+                i += 1
+            dict_list.append(data)
         return dict_list
 
 

--- a/tododb.py
+++ b/tododb.py
@@ -52,7 +52,7 @@ class DB(object):
         
         列を追加した際にアップデートとして用いられる
         """
-        dict_list = self.dict_list()
+        dict_list = self.dict_list(mode=1)
         self.__drop_table()
         self.__create_table()
         for i in range(len(dict_list)):
@@ -209,8 +209,11 @@ class DB(object):
             str_list += '\n'
         return str_list
 
-    def dict_list(self) ->list:
+
+    def dict_list(self,mode=0) ->list:
         """ToDo DB の各データをそれぞれdictにして、dictのリストを返す
+
+        引数でmode=1とすると、削除されたデータを含めて取得
 
         戻り値の形
         [{データ1 dict},{データ2 dict},{データ3 dict}]
@@ -223,8 +226,14 @@ class DB(object):
             for i in range(len(columns)):
                 data[columns[i][0]] = item[i]
                 i += 1
-            # 削除済みのものはここで排除する
-            if data["deleted"]==0:
+            # 削除済みのものはここで排除する。またint型に直すものを直す
+            data["id"]=int(data["id"])
+            data["noticetime"]=int(data["noticetime"])
+            if "deleted" in data.keys():
+                data["deleted"]=int(data["deleted"])
+                if mode==1 or data["deleted"]==0:
+                    dict_list.append(data)
+            else:
                 dict_list.append(data)
         return dict_list
 

--- a/tododb.py
+++ b/tododb.py
@@ -106,6 +106,8 @@ class DB(object):
             if item[0] in newdata.keys():
                 newdata[item[0]] = item[1]
         # ここで、limit_atがちゃんとフォーマットにあっているか見る
+        if newdata["limit_at"]==None:
+            newdata["limit_at"] = DEFAULT["limit_at"]
         if not re.match(r'^\d{4}/\d{2}/\d{2} \d{1,2}:\d{2}$', newdata["limit_at"]):
             newdata["limit_at"] = DEFAULT["limit_at"]
         # 現在時刻取得

--- a/tododb.py
+++ b/tododb.py
@@ -223,7 +223,9 @@ class DB(object):
             for i in range(len(columns)):
                 data[columns[i][0]] = item[i]
                 i += 1
-            dict_list.append(data)
+            # 削除済みのものはここで排除する
+            if data["deleted"]==0:
+                dict_list.append(data)
         return dict_list
 
 

--- a/tododb.py
+++ b/tododb.py
@@ -5,9 +5,9 @@ import time
 from plugins import tools
 
 DEFAULT = {"title": "Noname", "limit_at": "2999/12/31 23:59",
-           "update_at": "2000/01/01 0:00", "status": "未", "noticetime": 3, "user": None}
+           "update_at": "2000/01/01 0:00", "status": "未", "noticetime": 3, "user": None, "deleted": 0}
 DEFAULT_TYPE = {"title": "text NOT NULL", "limit_at": "text",
-                "update_at": "text NOT NULL", "status": "text", "noticetime": "integer NOT NULL", "user": "text"}
+                "update_at": "text NOT NULL", "status": "text", "noticetime": "integer NOT NULL", "user": "text", "deleted":"bit"}
 
 
 class DB(object):
@@ -50,17 +50,16 @@ class DB(object):
 
         このとき、テーブル内のデータは保たれる
         
-        idの値がとびとびになってしまった際や列を追加した際にアップデートとして用いられる
+        列を追加した際にアップデートとして用いられる
         """
         dict_list = self.dict_list()
         self.__drop_table()
         self.__create_table()
         for i in range(len(dict_list)):
-            # 本来ないはずだが不正なデータは追加しない
+            # 本来ないはずだが不正なデータは削除データとして追加
             if dict_list[i]["title"] == None or dict_list[i]["title"] == "None":
-                continue
-            if dict_list[i]["update_at"] == None or dict_list[i]["update_at"] == "None":
-                continue
+                dict_list[i]["deleted"]=1
+                dict_list[i]["limit_at"]=DEFAULT["limit_at"]
             self.add_dict(dict_list[i])
 
 


### PR DESCRIPTION
新しくDBの列にdelete列を追加しました。
それに伴う留意点は以下の通りです。
- `tododb.py`の`dict_list()`において通常ではdeleteの値が1であるものは取得しないようになりました。ただし、
```
data=dict_list(mode=1)
```
と入力することで削除されたデータをふくめて全データを取得することができます。
- idの番号が変わらないようになりました。これまでは、削除されたデータの前後のidがとびとびになり、`clean()`を行うとidがずれてしまいましたが、今回の更新により今後は`reset()`が行われない限りidで特定のデータを参照できるようになります。