### PR TITLE
deleted列に伴う既存の機能の拡張

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ ToDo 管理とその他さまざまな反応をする slackbot
   - `@bot todo add 'タイトル' [締切]`: ToDo 内容を登録する
   - `@bot todo list`: 参照した user の ToDo の一覧を表示する
   - `@bot todo list all`: ToDo の一覧を表示する
+  - `@bot todo delete 'id'`: 指定したidを削除する
   - `@bot todo reset`: ToDo の DB をリセットする
   - `@bot todo search '検索文字列'`: 検索文字列がtitleに含まれている場合、その内容を表示する
 
 ## ToDo DBのスキーマ
-| id | title |     limit_at     |    update_at     | status |  noticetime  |    user     |
-|----|-------|------------------|------------------|--------|--------------|-------------|
-|  1 | test1 | 2020/04/30 23:59 | 2020/04/01 13:10 |   済   |       0      | S2340A7K6Q4 |
-|  2 | test2 | 2020/07/30 7:05  | 2020/06/01 17:00 |   未   |       3      | S2340A7K6Q4 |
+| id | title |     limit_at     |    update_at     | status |  noticetime  |    user     | deleted |
+|----|-------|------------------|------------------|--------|--------------|-------------|---------|
+|  1 | test1 | 2020/04/30 23:59 | 2020/04/01 13:10 |   済   |       0      | S2340A7K6Q4 |    0    |
+|  2 | test2 | 2020/07/30 7:05  | 2020/06/01 17:00 |   未   |       3      | S2340A7K6Q4 |    1    |
 * 上のuseridは存在しないものである
 
 ## ToDo DBの操作関数
@@ -38,6 +39,7 @@ ToDo 管理とその他さまざまな反応をする slackbot
 * `clean()`主に開発時、テーブルの列の更新、不正なデータの削除を行う
 * `change_id(id, column, value)`指定したidのデータの値を変更する
 * `search(column, text)`columnの値にtextが含まれる場合そのデータをlist形式(要素はdict形式)で返す
+* `delete_id(id, userid)`指定したデータを削除する。他のユーザのものは消せない。
 
 ## 諸機能の補助関数(tools.py)
 * `getmsginfo(message)`:messageからユーザー情報を取得

--- a/plugins/listen.py
+++ b/plugins/listen.py
@@ -8,6 +8,7 @@ def com_set(message):
     text = message.body['text'][1:]
 
     todo_add = re.search(r'^add\s+(\S+)\s+(\S+)$', text)
+    todo_delete = re.search(r'^delete\s+(\d+)$', text)
     todo_list = re.search(r'^list$', text)
     todo_list_all = re.search(r'^list\s+all$', text)
     todo_reset = re.search(r'^reset$', text)
@@ -16,6 +17,8 @@ def com_set(message):
 
     if todo_add:
         todo.todo_add(message, todo_add.group(1), todo_add.group(2))
+    elif todo_delete:
+        todo.todo_delete(message,todo_delete.group(1))
     elif todo_list:
         todo.todo_list(message)
     elif todo_list_all:

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -4,6 +4,24 @@ from . import tools
 import os
 import datetime
 
+@respond_to(r'\s*todo\s+delete\s+(\d+)$')
+def todo_delete(message, id):
+    db = DB(os.environ['TODO_DB'])
+    userid = tools.getmsginfo(message)["user_id"]
+    result = db.delete_id(id, userid)
+    if result==200:
+        msg = f"id{id}番を削除しました。"
+    elif result==401:
+        msg = f"idが不正です。"
+    elif result==402:
+        msg = f"sql文が上手く実行できませんでした。"
+    elif result==-1:
+        msg = f"他のユーザーのものは変更できません。"
+    else:
+        msg = "うまくいきませんでした。"
+    message.reply(msg)
+
+
 @respond_to(r'\s+todo\s+add\s+(\S+)\s+(\S+)$')
 def todo_add(message, title, limit_at):
     # ユーザー情報取得

--- a/plugins/tools.py
+++ b/plugins/tools.py
@@ -11,14 +11,20 @@ def getmsginfo(message)-> dict:
     """ユーザー情報をdict形式で返す
     現在得られるのは
     
-    channel:チャンネル名
+    channel:チャンネル名(DMの場合はNone)
+    
+    channel_id:チャンネル固有のid
 
     user_id:ユーザー固有のid
 
     user_name:ユーザー名
     """
     info_dict={}
-    info_dict["channel"] = message.channel._body["name"]
+    try:
+        info_dict["channel"] = message.channel._body["name"]
+    except KeyError:
+        info_dict["channel"] = None
+    info_dict["channel_id"] = message.channel._body["id"]
     info_dict["user_id"] = message.user["id"]
     info_dict["user_name"] = message.user["real_name"]
     return info_dict

--- a/tododb.py
+++ b/tododb.py
@@ -236,6 +236,28 @@ class DB(object):
             else:
                 dict_list.append(data)
         return dict_list
+    
+    def dict_list_sorted(self, keycolumn="limit_at",show_over_deadline=0, showdeleted=0, user_id=None) ->list:
+        """ToDo DB の各データをそれぞれdictにして、dictのリストを返す
+        
+        全データ期限の早い順に並び変えられている。
+
+        引数でkeycolumn= 列の名前 とすると、指定した列でソート（基本はlimit_at用なので、それ以外は対応していない可能性あり）
+        
+        引数でshowdeleted=1 とすると、削除されたデータを含めて取得
+
+        引数でshow_over_deadline=0 とすると、期限切れのものを含めて取得
+
+        引数でuser_id= ユーザーのid とすると、特定ユーザーのデータのみ取得
+
+        戻り値の形
+        [{データ1 dict},{データ2 dict},{データ3 dict}]
+        """
+
+        dict_list=self.dict_list(mode=showdeleted)
+        data_sorted = sorted(dict_list, key=lambda x: x[keycolumn])
+
+        return data_sorted
 
 
     def search(self, column, text, mode=0) ->list:

--- a/tododb.py
+++ b/tododb.py
@@ -62,6 +62,16 @@ class DB(object):
                 dict_list[i]["limit_at"]=DEFAULT["limit_at"]
             self.add_dict(dict_list[i])
 
+    def delete_id(self, id: str, userid) -> int:
+        """指定したidのデータを削除する
+
+        ユーザーに権限がない場合は-1を返す
+        """
+        if self.select_id(id)["user"]==userid:
+            result = self.change_id(id, "deleted", 1)
+        else:
+            result = -1
+        return result
 
 
     def select_id(self, id: str) -> dict:

--- a/tododb.py
+++ b/tododb.py
@@ -49,7 +49,7 @@ class DB(object):
         """一度テーブルを削除して再生成する
 
         このとき、テーブル内のデータは保たれる
-        
+
         列を追加した際にアップデートとして用いられる
         """
         dict_list = self.dict_list(mode=1)
@@ -63,7 +63,7 @@ class DB(object):
             self.add_dict(dict_list[i])
 
 
-    
+
     def select_id(self, id: str) -> dict:
         """idでデータを取得してdict形式で返す
 
@@ -89,7 +89,7 @@ class DB(object):
 
     def add_dict(self, data:dict)-> dict:
         """追加するデータをdictionaryで受け取る
-        
+
         引数 (self,追加したいデータ:dict)
 
         return 追加したデータ
@@ -191,7 +191,7 @@ class DB(object):
 
     def add(self, title: str, limit_at: str):
         """title と limit_at (有効期限) を登録
-        
+
         これは既存のシステムを保つためにあるものなので、add_dict()を使ってほしい
         """
         update_at = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -209,15 +209,19 @@ class DB(object):
             str_list += '\n'
         return str_list
 
-
-    def dict_list(self,mode=0) ->list:
+    def dict_list(self, mode=0, show_over_deadline=1, user_id=None) -> list:
         """ToDo DB の各データをそれぞれdictにして、dictのリストを返す
 
         引数でmode=1とすると、削除されたデータを含めて取得
 
+        引数でshow_over_deadline=0 とすると、期限切れのものを含めて取得
+
+        引数でuser_id= ユーザーのid とすると、特定ユーザーのデータのみ取得
+
         戻り値の形
         [{データ1 dict},{データ2 dict},{データ3 dict}]
         """
+        now = datetime.datetime.now()
         dict_list = []
         columns = self.__conn.execute("select * from todo").description
         for r in self.__c.execute(f"select * from todo"):
@@ -231,19 +235,26 @@ class DB(object):
             data["noticetime"]=int(data["noticetime"])
             if "deleted" in data.keys():
                 data["deleted"]=int(data["deleted"])
-                if mode==1 or data["deleted"]==0:
-                    dict_list.append(data)
-            else:
-                dict_list.append(data)
+                if mode == 0 and data["deleted"] == 1:
+                    continue
+            # 期限切れのものを排除する
+            if show_over_deadline == 0:
+                if datetime.datetime.strptime(data["limit_at"], '%Y/%m/%d %H:%M')-now < datetime.timedelta(hours=0):
+                    continue
+            # 他のユーザーのものを排除する
+            if user_id != None:
+                if data["user"] != user_id and data["user"] !="all":
+                    continue
+            dict_list.append(data)
         return dict_list
-    
-    def dict_list_sorted(self, keycolumn="limit_at",show_over_deadline=0, showdeleted=0, user_id=None) ->list:
+
+    def dict_list_sorted(self, keycolumn="limit_at", show_over_deadline=0, showdeleted=0, user_id=None) -> list:
         """ToDo DB の各データをそれぞれdictにして、dictのリストを返す
-        
+
         全データ期限の早い順に並び変えられている。
 
         引数でkeycolumn= 列の名前 とすると、指定した列でソート（基本はlimit_at用なので、それ以外は対応していない可能性あり）
-        
+
         引数でshowdeleted=1 とすると、削除されたデータを含めて取得
 
         引数でshow_over_deadline=0 とすると、期限切れのものを含めて取得
@@ -254,7 +265,7 @@ class DB(object):
         [{データ1 dict},{データ2 dict},{データ3 dict}]
         """
 
-        dict_list=self.dict_list(mode=showdeleted)
+        dict_list=self.dict_list(mode=showdeleted, show_over_deadline=show_over_deadline, user_id=user_id)
         data_sorted = sorted(dict_list, key=lambda x: x[keycolumn])
 
         return data_sorted


### PR DESCRIPTION
主な変更は以下の通りです。
 - tododb.pyに`delete_id()`を追加しました。
 - todo delete で指定したidのデータを削除できるようになりました。
 - messageからchannelの固有idが得られるようになりました。

ここで、削除というのはテーブルの列のdeletedが1に変わるだけのことなので、データ自体は残っていることに注意してください。