### PR TITLE
データ列を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,24 @@ ToDo 管理とその他さまざまな反応をする slackbot
   - `@bot todo list`: 参照した user の ToDo の一覧を表示する
   - `@bot todo list all`: ToDo の一覧を表示する
   - `@bot todo delete 'id'`: 指定したidを削除する
+  - `@bot todo delete_secret 'id'`: 指定したidを削除し、その内容も初期化する
+  - `@bot todo cancel_announcement 'id'`: 指定した全体への告知を削除する
+  - `@bot todo announce 'タイトル' '日時' '備考'`: 全員共通のことについて、全体への告知を作成する
   - `@bot todo reset`: ToDo の DB をリセットする
   - `@bot todo search '検索文字列'`: 検索文字列がtitleに含まれている場合、その内容を表示する
 
 ## ToDo DBのスキーマ
-| id | title |     limit_at     |    update_at     | status |  noticetime  |    user     | deleted |
-|----|-------|------------------|------------------|--------|--------------|-------------|---------|
-|  1 | test1 | 2020/04/30 23:59 | 2020/04/01 13:10 |   済   |       0      | S2340A7K6Q4 |    0    |
-|  2 | test2 | 2020/07/30 7:05  | 2020/06/01 17:00 |   未   |       3      | S2340A7K6Q4 |    1    |
+|id|title|    limit_at    |   update_at    |status|noticetime|   user    |deleted|
+|--|-----|----------------|----------------|------|----------|-----------|-------|
+| 1|test1|2020/04/30 23:59|2020/04/01 13:10|  済  |     0    |S2340A7K6Q4|   0   |
+| 2|test2|2020/07/30 7:05 |2020/06/01 17:00|  未  |     3    |S2340A7K6Q4|   1   |
+
+多くなったので入りきらないが、以下は上のテーブルの右につながる。
+|subject|note|importance|
+|-------|----|----------|
+|science|None|    中    |
+| None  | あ |    大    |
+
 * 上のuseridは存在しないものである
 
 ## ToDo DBの操作関数
@@ -49,6 +59,7 @@ ToDo 管理とその他さまざまな反応をする slackbot
 * `postMessage(text, attachments, channel, username="お知らせ", icon_emoji)`:messageをpost
 * `updateMessage(text, attachments, ts, channel, username="お知らせ", icon_emoji)`:messageを編集
 * `noticetimeSet(limit_at:datetime, now)`:期限から残り通知回数を定める
+* `order(data,column)`:データ列のソートの順序を定めるする
 
 ## テスト用プログラム
 * test_regex.py

--- a/plugins/listen.py
+++ b/plugins/listen.py
@@ -8,7 +8,9 @@ def com_set(message):
     text = message.body['text'][1:]
 
     todo_add = re.search(r'^add\s+(\S+)\s+(\S+)$', text)
+    todo_delete_secret = re.search(r'^delete_secret\s+(\d+)$', text)
     todo_delete = re.search(r'^delete\s+(\d+)$', text)
+    todo_cancel_announcement = re.search(r'^cancel_announcement\s+(\d+)$', text)
     todo_list = re.search(r'^list$', text)
     todo_list_all = re.search(r'^list\s+all$', text)
     todo_reset = re.search(r'^reset$', text)
@@ -18,8 +20,12 @@ def com_set(message):
 
     if todo_add:
         todo.todo_add(message, todo_add.group(1), todo_add.group(2))
+    elif todo_delete_secret:
+        todo.todo_delete_secret(message,todo_delete_secret.group(1))
     elif todo_delete:
         todo.todo_delete(message,todo_delete.group(1))
+    elif todo_cancel_announcement:
+        todo.todo_cancel_announcement(message,todo_cancel_announcement.group(1))
     elif todo_list:
         todo.todo_list(message)
     elif todo_list_all:

--- a/plugins/listen.py
+++ b/plugins/listen.py
@@ -14,6 +14,7 @@ def com_set(message):
     todo_reset = re.search(r'^reset$', text)
     todo_search = re.search(r'^search\s+(\S+)$', text)
     todo_change_id = re.search(r'^change\s+(\S+)\s+(\S+)\s+(\S+)$', text)
+    todo_announce = re.search(r'^announce\s+(\S+)\s+(\S+)\s+(\S+)$', text)
 
     if todo_add:
         todo.todo_add(message, todo_add.group(1), todo_add.group(2))
@@ -30,6 +31,8 @@ def com_set(message):
     elif todo_change_id: 
         todo.todo_change_id(message, todo_change_id.group(1), \
             todo_change_id.group(2), todo_change_id.group(3))
+    elif todo_announce:
+        todo.todo_announce(message, todo_announce.group(1), todo_announce.group(2), todo_announce.group(3))
     else:
         message.reply('このコマンドは無効です')
 

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -4,6 +4,24 @@ from . import tools
 import os
 import datetime
 
+@respond_to(r'\s*todo\s+delete_secret\s+(\d+)$')
+def todo_delete_secret(message, id):
+    db = DB(os.environ['TODO_DB'])
+    userid = tools.getmsginfo(message)["user_id"]
+    result = db.delete_id(id, userid,secret=True)
+    if result==200:
+        msg = f"id{id}番を削除しました。また、id{id}番データ内容は初期化されました。"
+    elif result==401:
+        msg = f"idが不正です。"
+    elif result==402:
+        msg = f"sql文が上手く実行できませんでした。"
+    elif result==-1:
+        msg = f"他のユーザーのものは変更できません。"
+    else:
+        msg = "うまくいきませんでした。"
+    message.reply(msg)
+
+
 @respond_to(r'\s*todo\s+delete\s+(\d+)$')
 def todo_delete(message, id):
     db = DB(os.environ['TODO_DB'])
@@ -20,6 +38,24 @@ def todo_delete(message, id):
     else:
         msg = "うまくいきませんでした。"
     message.reply(msg)
+
+
+@respond_to(r'\s*todo\s+cancel\s+announcement\s+(\d+)$')
+def todo_cancel_announcement(message, id):
+    db = DB(os.environ['TODO_DB'])
+    result = db.delete_id(id, "all")
+    if result==200:
+        msg = f"id{id}番のannouncementを削除しました。"
+    elif result==401:
+        msg = f"idが不正です。"
+    elif result==402:
+        msg = f"sql文が上手く実行できませんでした。"
+    elif result==-1:
+        msg = f"指定されたidのデータはannouncementではありません。"
+    else:
+        msg = "うまくいきませんでした。"
+    message.reply(msg)
+
 
 
 @respond_to(r'\s+todo\s+add\s+(\S+)\s+(\S+)$')

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -52,6 +52,29 @@ def todo_add_unlimit(message, title):
     database = DB(os.environ['TODO_DB'])
     database.add(title, None)
 
+
+@respond_to(r'todo\s+announce\s+(\S+)\s+(\S+)\s+(\S+)$')
+def todo_announce(message, title, limit_at, note):
+    data= {"title": title, "limit_at": limit_at,"user": "all", "note": note}
+    database = DB(os.environ['TODO_DB'])
+    now = datetime.datetime.now()
+    limit_at_fin = tools.datetrans(limit_at, now)
+    msg="以下の内容で"
+    if limit_at_fin != None:
+        limit_at_format = datetime.datetime.strptime(limit_at_fin, '%Y/%m/%d %H:%M')
+        if now > limit_at_format:
+            data["status"] = '期限切れ'
+        noticetime = tools.noticetimeSet(limit_at_format, now)
+        data["noticetime"]=noticetime
+        data["limit_at"]=limit_at_fin
+        msg += "、期限を正しく設定して"
+    data = database.add_dict(data)
+    msg += "追加しました。"
+    for item in data.items():
+        msg+=f"\n{item[0]}: {item[1]}"
+    message.reply(msg)
+
+
 @respond_to(r'\s*todo\s+list$')
 def todo_list(message):
     database = DB(os.environ['TODO_DB'])

--- a/plugins/tools.py
+++ b/plugins/tools.py
@@ -162,3 +162,28 @@ def noticetimeSet(limit_at:datetime, now):
     elif diff < datetime.timedelta(days=3):
         noticetime = 2
     return noticetime
+
+def order(data: str,column: str):
+    """データの順序を定める。
+    
+    大小比較によるソートに利用される。
+    
+    """
+    if column == "importance":
+        if data == "大":
+            return 1
+        if data == "中":
+            return 2
+        if data == "小":
+            return 3
+        return 0
+    if column == "status":
+        if data == "未":
+            return 1
+        if data == "期限切れ":
+            return 2
+        if data == "済":
+            return 3
+        return 0
+    return data
+    

--- a/tododb.py
+++ b/tododb.py
@@ -278,7 +278,7 @@ class DB(object):
         """
 
         dict_list=self.dict_list(mode=showdeleted, show_over_deadline=show_over_deadline, user_id=user_id)
-        data_sorted = sorted(dict_list, key=lambda x: x[keycolumn])
+        data_sorted = sorted(dict_list, key=lambda x: tools.order(x[keycolumn],keycolumn))
 
         return data_sorted
 

--- a/tododb.py
+++ b/tododb.py
@@ -62,13 +62,22 @@ class DB(object):
                 dict_list[i]["limit_at"]=DEFAULT["limit_at"]
             self.add_dict(dict_list[i], update_update_at = 0)
 
-    def delete_id(self, id: str, userid) -> int:
+    def delete_id(self, id: str, userid: str, secret = False) -> int:
         """指定したidのデータを削除する
 
         ユーザーに権限がない場合は-1を返す
+
+        オプションで内容も初期化することが出来る。
         """
         if self.select_id(id)["user"]==userid:
             result = self.change_id(id, "deleted", 1)
+            if result == 200 and secret:
+                for key, value in DEFAULT.items():
+                    if key=="deleted" or key=="id" or key=="update_at" or key=="user":
+                        continue
+                    result = self.change_id(id, key, value)
+                    if result != 200:
+                        break
         else:
             result = -1
         return result

--- a/tododb.py
+++ b/tododb.py
@@ -5,9 +5,9 @@ import time
 from plugins import tools
 
 DEFAULT = {"title": "Noname", "limit_at": "2999/12/31 23:59",
-           "update_at": "2000/01/01 0:00", "status": "未", "noticetime": 3, "user": None, "deleted": 0}
+           "update_at": "2000/01/01 0:00", "status": "未", "noticetime": 3, "user": None, "deleted": 0, "subject": None,"note": None,"importance": "中"}
 DEFAULT_TYPE = {"title": "text NOT NULL", "limit_at": "text",
-                "update_at": "text NOT NULL", "status": "text", "noticetime": "integer NOT NULL", "user": "text", "deleted":"bit"}
+                "update_at": "text NOT NULL", "status": "text", "noticetime": "integer NOT NULL", "user": "text", "deleted":"bit", "subject": "text","note": "text","importance": "text NOT NULL"}
 
 
 class DB(object):


### PR DESCRIPTION
いくつか機能の追加があるので、slackとの入出力でこれらの機能を使いたい場合はこのプルリクエストがMergeされた後に、授業での手続きに従って、fetch、rebaseして利用することを強く推奨します。

- 教科名や教科ジャンルを書く`subject`列の追加
教科やジャンルなど、ここから検索してデータを持ってくることも可能ですが、現状教科名やジャンルを入れるslack上のコマンドがないので、どなたか追加をお願いします。

- 備考を記す`note`列の追加
備考欄としてタスクの注意点や追加情報などを書き込むための列です。現状改行は認められませんが、文字数制限は特にありません。

- 重要度（優先度）を記す`importance`列の追加
この列には大、中、小のいずれかを入れるようにしてください。この列はデフォルトでは中となっています。

- 自分だけでなく他の人全員共通の課題（どちらかというとイベント）を登録する`announce`コマンドの追加
この方法で登録されたものは、`user`が`"all"`としてテーブルに格納され、すべてのユーザーが見られるようになります。

- データを削除する際に、`deleted`列が`1`になるだけでなく、情報を初期化する`delete_secret`コマンドの追加
セキュリティの都合上まずいと思ったデータ（例えば住所や銀行情報などを備考に入れてしまったタスク）について、`id`を指定してこの操作を行うことで、テーブル上でのそのデータがデフォルトに戻ります。（`user`と`update_at`、`deleted`は戻りません。）

- 全員共通の課題（どちらかというとイベント）を取り消す`cancel_announcement`コマンドの追加
この方法で`user`が`"all"`としてテーブルに格納されているデータを消すことができます。誰かが取り消すと全員取り消したことになるので注意してください。

