### PR TITLE
todo.pyのtodo_add_sub()に操作を任せる

### DIFF
--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -66,8 +66,9 @@ def todo_add(message, title, limit_at):
 
 @respond_to(r'\s+todo\s+add\s+(\S+)$')
 def todo_add_unlimit(message, title):
-    database = DB(os.environ['TODO_DB'])
-    database.add(title, None)
+    data={"title": title}
+    msg=todo_add_sub(message,data)
+    message.reply(msg)
 
 
 @respond_to(r'todo\s+announce\s+(\S+)\s+(\S+)\s+(\S+)$')

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -91,24 +91,9 @@ def todo_add_unlimit(message, title):
 
 @respond_to(r'todo\s+announce\s+(\S+)\s+(\S+)\s+(\S+)$')
 def todo_announce(message, title, limit_at, note):
-    data= {"title": title, "limit_at": limit_at,"user": "all", "note": note}
-    database = DB(os.environ['TODO_DB'])
-    now = datetime.datetime.now()
-    limit_at_fin = tools.datetrans(limit_at, now)
-    msg="以下の内容で"
-    if limit_at_fin != None:
-        limit_at_format = datetime.datetime.strptime(limit_at_fin, '%Y/%m/%d %H:%M')
-        if now > limit_at_format:
-            data["status"] = '期限切れ'
-        noticetime = tools.noticetimeSet(limit_at_format, now)
-        data["noticetime"]=noticetime
-        data["limit_at"]=limit_at_fin
-        msg += "、期限を正しく設定して"
-    data = database.add_dict(data)
-    msg += "追加しました。"
-    for item in data.items():
-        msg+=f"\n{item[0]}: {item[1]}"
-        message.reply(msg)
+    data= {"title": title, "limit_at": limit_at, "note": note}
+    msg=todo_add_sub(message,data,announce=True)
+    message.reply(msg)
 
 
 @respond_to(r'\s*todo\s+list$')

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -171,14 +171,13 @@ def todo_add_sub(message,data:dict,announce=False) -> str:
             msg+=f"\n{item[0]}: {item[1]}"
         return msg
     if "status" in data.keys():
-        if data["status"]=="済":
-            data["noticetime"]=3
-            data = database.add_dict(data)
-            msg="以下の内容で追加しました。\n"
-            for item in data.items():
-                if item[0]=="user":
-                    continue
-                msg+=f"\n{item[0]}: {item[1]}"
-            return msg
+        data["noticetime"]=3
+        data = database.add_dict(data)
+        msg="以下の内容で追加しました。\n"
+        for item in data.items():
+            if item[0]=="user":
+                continue
+            msg+=f"\n{item[0]}: {item[1]}"
+        return msg
     return "何らかの不具合により追加できません。"
         

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -60,27 +60,8 @@ def todo_cancel_announcement(message, id):
 
 @respond_to(r'\s+todo\s+add\s+(\S+)\s+(\S+)$')
 def todo_add(message, title, limit_at):
-    # ユーザー情報取得
-    info=tools.getmsginfo(message)
-    data= {"title": title, "limit_at": limit_at,"user": info["user_id"]}
-    database = DB(os.environ['TODO_DB'])
-    now = datetime.datetime.now()
-    limit_at_fin = tools.datetrans(limit_at, now)
-    msg="以下の内容で"
-    if limit_at_fin != None:
-        limit_at_format = datetime.datetime.strptime(limit_at_fin, '%Y/%m/%d %H:%M')
-        if now > limit_at_format:
-            data["status"] = '期限切れ'
-        noticetime = tools.noticetimeSet(limit_at_format, now)
-        data["noticetime"]=noticetime
-        data["limit_at"]=limit_at_fin
-        msg += "、期限を正しく設定して"
-    data = database.add_dict(data)
-    msg += "追加しました。"
-    for item in data.items():
-        if item[0]=="user":
-            continue
-        msg+=f"\n{item[0]}: {item[1]}"
+    data={"title": title,"limit_at": limit_at}
+    msg=todo_add_sub(message,data)
     message.reply(msg)
 
 @respond_to(r'\s+todo\s+add\s+(\S+)$')

--- a/plugins/todo.py
+++ b/plugins/todo.py
@@ -108,7 +108,7 @@ def todo_announce(message, title, limit_at, note):
     msg += "追加しました。"
     for item in data.items():
         msg+=f"\n{item[0]}: {item[1]}"
-    message.reply(msg)
+        message.reply(msg)
 
 
 @respond_to(r'\s*todo\s+list$')
@@ -166,3 +166,52 @@ def todo_change_id(message, id, column, value):
     elif status_code == 200:
         msg = '値を変更しました'
     message.reply(msg)
+
+def todo_add_sub(message,data:dict,announce=False) -> str:
+    """データ登録の際はこのtodo_add_subにmessageとデータのディクショナリを与えてください。
+
+    戻り値は、登録内容をお知らせする文字列となっています。
+    """
+    # ユーザー情報取得
+    if announce:
+        data["user"]="all"
+    else:
+        info=tools.getmsginfo(message)
+        data["user"]=info["user_id"]
+    database = DB(os.environ['TODO_DB'])
+    now = datetime.datetime.now()
+    if "limit_at" in data.keys() or not "status" in data.keys():
+        if not "limit_at" in data.keys() and not "status" in data.keys():
+            data["limit_at"]=None
+        limit_at_fin = tools.datetrans(data["limit_at"], now)
+        msg="以下の内容で"
+        if limit_at_fin != None or data["limit_at"] == None:
+            if data["limit_at"] != None:
+                limit_at_format = datetime.datetime.strptime(limit_at_fin, '%Y/%m/%d %H:%M')
+                if now > limit_at_format:
+                    data["status"] = '期限切れ'
+                noticetime = tools.noticetimeSet(limit_at_format, now)
+                data["noticetime"]=noticetime
+                data["limit_at"]=limit_at_fin
+            msg += "、期限を正しく設定して"
+        else:
+            return "limit_atの形が不正です。以下の入力例を参考にしてください。\n202008161918: 2020年8月16日19時18分となります。\n0816: 現在以降で最も早い8月16日23時59分となります。"
+        data = database.add_dict(data)
+        msg += "追加しました。"
+        for item in data.items():
+            if item[0]=="user":
+                continue
+            msg+=f"\n{item[0]}: {item[1]}"
+        return msg
+    if "status" in data.keys():
+        if data["status"]=="済":
+            data["noticetime"]=3
+            data = database.add_dict(data)
+            msg="以下の内容で追加しました。\n"
+            for item in data.items():
+                if item[0]=="user":
+                    continue
+                msg+=f"\n{item[0]}: {item[1]}"
+            return msg
+    return "何らかの不具合により追加できません。"
+        

--- a/plugins/tools.py
+++ b/plugins/tools.py
@@ -37,6 +37,9 @@ def datetrans(limit_at, now, mode=0):
     limit_at_str = ''
     limit_at = mojimoji.zen_to_han(limit_at, kana=False, ascii=False)
     date_format = "%Y%m%d%H%M"
+    # NoneにはNoneを返す
+    if limit_at==None:
+        return None
     limit_at = limit_at.replace("/","")
     limit_at = limit_at.replace(":","")
     limit_at = limit_at.replace(" ","")


### PR DESCRIPTION
todo_add_sub()は従来todo_add()内で行っていたnoticetimeやlimit_at,statusの設定を任せるために作られています。今後のあらゆるタスクの追加方法はこの関数を通してもらえると助かります。